### PR TITLE
InBarrierError の項目追加

### DIFF
--- a/trajectory_gcs_service/protocol/v1/route_service.proto
+++ b/trajectory_gcs_service/protocol/v1/route_service.proto
@@ -78,13 +78,20 @@ message ListVoxelsAroundPathsResponse {
 
         // 障害物の種類 (AIP-126 により接頭辞無し)
         enum BarrierType {
-            UNSPECIFIED = 0; // 未指定 (デフォルト)
-            BARRIER = 1;     // 永続的バリア
-            TERRAIN = 2;     // 地形
-            AIRWAY = 3;      // 航路
-            TEMPORARY = 4;   // 一時的バリア
-            ROUTE = 5;       // ルートバリア
-            PORT = 6;        // ポート
+            // 未指定 (デフォルト)
+            UNSPECIFIED = 0;
+            // 永続的バリア
+            BARRIER = 1;
+            // 地形
+            TERRAIN = 2;
+            // 航路
+            AIRWAY = 3;
+            // 一時的バリア
+            TEMPORARY = 4;
+            // ルートバリア
+            ROUTE = 5;
+            // ポート
+            PORT = 6;
         }
 
         // 経路が存在しないエラー

--- a/trajectory_gcs_service/protocol/v1/route_service.proto
+++ b/trajectory_gcs_service/protocol/v1/route_service.proto
@@ -76,13 +76,15 @@ message ListVoxelsAroundPathsResponse {
             map<int64, BarrierType> barrier_types_by_id = 4;
         }
 
-        // 障害物の種類
+        // 障害物の種類 (AIP-126 により接頭辞無し)
         enum BarrierType {
-            BARRIER_TYPE_UNKNOWN = 0;   // 不明 (デフォルト)
-            BARRIER_TYPE_PERMANENT = 1; // 永続的バリア
-            BARRIER_TYPE_TEMPORARY = 2; // 一時的バリア
-            BARRIER_TYPE_TERRAIN = 3;   // 地形バリア
-            BARRIER_TYPE_AIRWAY = 4;    // 航路バリア
+            UNSPECIFIED = 0; // 未指定 (デフォルト)
+            BARRIER = 1;     // 永続的バリア
+            TERRAIN = 2;     // 地形
+            AIRWAY = 3;      // 航路
+            TEMPORARY = 4;   // 一時的バリア
+            ROUTE = 5;       // ルートバリア
+            PORT = 6;        // ポート
         }
 
         // 経路が存在しないエラー

--- a/trajectory_gcs_service/protocol/v1/route_service.proto
+++ b/trajectory_gcs_service/protocol/v1/route_service.proto
@@ -73,7 +73,16 @@ message ListVoxelsAroundPathsResponse {
             // 障害物に衝突してしまう位置
             trajectory.trjx_api_service.Position position = 2;
             // 障害物の オブジェクトID:バリア型 の情報
-            map<int64, string> barrier_types_by_id = 4;
+            map<int64, BarrierType> barrier_types_by_id = 4;
+        }
+
+        // 障害物の種類
+        enum BarrierType {
+            BARRIER_TYPE_UNKNOWN = 0;   // 不明 (デフォルト)
+            BARRIER_TYPE_PERMANENT = 1; // 永続的バリア
+            BARRIER_TYPE_TEMPORARY = 2; // 一時的バリア
+            BARRIER_TYPE_TERRAIN = 3;   // 地形バリア
+            BARRIER_TYPE_AIRWAY = 4;    // 航路バリア
         }
 
         // 経路が存在しないエラー

--- a/trajectory_gcs_service/protocol/v1/route_service.proto
+++ b/trajectory_gcs_service/protocol/v1/route_service.proto
@@ -80,18 +80,24 @@ message ListVoxelsAroundPathsResponse {
         enum BarrierType {
             // 未指定 (デフォルト)
             UNSPECIFIED = 0;
+            // 禁止空域、制限空域、訓練等空域、一時制限空域
+            RESTRICTED_AREA = 1;
+            // 最高高度以上の空域
+            ABOVE_MAX_ALTITUDE = 2;
+            // 最低高度以下の空域
+            BELOW_MIN_ALTITUDE = 3;
             // 永続的バリア
-            BARRIER = 1;
-            // 地形
-            TERRAIN = 2;
-            // 航路
-            AIRWAY = 3;
+            PERMANENT_BARRIER = 4;
             // 一時的バリア
-            TEMPORARY = 4;
-            // ルートバリア
-            ROUTE = 5;
+            TEMPORARY_BARRIER = 5;
+            // 地形
+            TERRAIN = 6;
+            // 航路
+            UASL = 7;
+            // ルート
+            ROUTE = 8;
             // ポート
-            PORT = 6;
+            PORT = 9;
         }
 
         // 経路が存在しないエラー

--- a/trajectory_gcs_service/protocol/v1/route_service.proto
+++ b/trajectory_gcs_service/protocol/v1/route_service.proto
@@ -72,6 +72,8 @@ message ListVoxelsAroundPathsResponse {
             Path danger_path = 3;
             // 障害物に衝突してしまう位置
             trajectory.trjx_api_service.Position position = 2;
+            // 障害物の オブジェクトID:バリア型 の情報
+            map<string, string> barrier_types_by_id = 4;
         }
 
         // 経路が存在しないエラー

--- a/trajectory_gcs_service/protocol/v1/route_service.proto
+++ b/trajectory_gcs_service/protocol/v1/route_service.proto
@@ -73,7 +73,7 @@ message ListVoxelsAroundPathsResponse {
             // 障害物に衝突してしまう位置
             trajectory.trjx_api_service.Position position = 2;
             // 障害物の オブジェクトID:バリア型 の情報
-            map<string, string> barrier_types_by_id = 4;
+            map<int64, string> barrier_types_by_id = 4;
         }
 
         // 経路が存在しないエラー


### PR DESCRIPTION
RouteService の ListVoxelsAroundPathsResponse 内に InBarrierError の項目を追加しました。確認お願いします。

### 確認内容
コンパイルが通るか。

### コンパイル方法
任意のカレントディレクトリ `.` に `github.com/trajectoryjp/trjx_api_service` のようなディレクトリ構成で公開 API を配置する。次のコマンドでコンパイルする
```bash
protoc --go_out=. --go-grpc_out=. github.com/trajectoryjp/trjx_api_service/**/*.proto
```

### 備考
こちらで `develop` branch にマージしてコンパイルの確認をしましたが、develop branch の `waypoint_service.proto` 内の以下の項目の方が不適切のようです。
CheckWaypointResponse (message) 内
- float64 latitude = 3;
- float64 longitude = 4;
- float32 altitude = 5;

正しくは float64 → double, float32 → float です。
https://protobuf.dev/programming-guides/proto3/