### PR TITLE
feat(project_service): implement  ProjectService

### DIFF
--- a/trajectory_gcs_service/protocol/v1/project_service.proto
+++ b/trajectory_gcs_service/protocol/v1/project_service.proto
@@ -266,7 +266,7 @@ service ProjectService {
 
 message Project {
     // プロジェクトID
-    ProjectID id = 1 [(google.api.field_behavior) = IDENTIFIER];
+    ProjectID id = 1;
     // プロジェクト名
     string name = 2;
     // プロジェクトの説明
@@ -280,6 +280,9 @@ message Project {
 
 // プロジェクト作成リクエスト
 message CreateProjectRequest {
+    // 作成対象のプロジェクト情報。
+    // project.id はサーバー側で自動生成されるため、リクエスト時に設定する必要はありません。
+    // 値が設定されている場合でも、サーバー側で無視または上書きされます。
     Project project = 1[(google.api.field_behavior) = REQUIRED];
 }
 
@@ -291,7 +294,10 @@ message GetProjectRequest {
 
 // プロジェクトリスト取得リクエスト
 message ListProjectsRequest {
-    int32 page_size = 1;  // ページサイズ, default= 25
+    // 取得するプロジェクトの最大件数。
+    // 0 または未指定の場合、サーバー側でデフォルト値 (20) が適用されます。
+    // 最大値は 70 です。
+    int32 page_size = 1;
     string page_token = 2; // ページトークン
 }
 

--- a/trajectory_gcs_service/protocol/v1/project_service.proto
+++ b/trajectory_gcs_service/protocol/v1/project_service.proto
@@ -16,8 +16,8 @@ service ProjectService {
     // CreateProject: プロジェクトの作成
     rpc CreateProject(CreateProjectRequest) returns (Project) {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "プロジェクトの作成する";
-            description: "プロジェクトの作成をする。admin権限が必要\n\n"
+            summary: "プロジェクトを作成する";
+            description: "プロジェクトを作成する。admin権限が必要。\n\n"
                          "エラーレスポンスの`details`には、以下のエラーコードが含まれる可能性がある。\n"
                          "エラーコードの詳細は https://trjxdoc.trajectory.jp/BEGatewaySpesification/error_codes.html を参照。\n\n"
                          "- `4009`\n"
@@ -108,7 +108,7 @@ message GetProjectRequest {
 // プロジェクトリスト取得リクエスト
 message ListProjectsRequest {
     // 取得するプロジェクトの最大件数。
-    // 0 または未指定の場合、サーバー側でデフォルト値 (20) が適用されます。
+    // 0 の場合、サーバー側でデフォルト値 (20) が適用されます。
     // 最大値は 70 です。
     int32 page_size = 1;
     string page_token = 2; // ページトークン

--- a/trajectory_gcs_service/protocol/v1/project_service.proto
+++ b/trajectory_gcs_service/protocol/v1/project_service.proto
@@ -17,7 +17,7 @@ service ProjectService {
     rpc CreateProject(CreateProjectRequest) returns (Project) {
         option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
             summary: "プロジェクトの作成する";
-            description: "プロジェクトの作成をする。\n\n"
+            description: "プロジェクトの作成をする。admin権限が必要\n\n"
                          "エラーレスポンスの`details`には、以下のエラーコードが含まれる可能性がある。\n"
                          "エラーコードの詳細は https://trjxdoc.trajectory.jp/BEGatewaySpesification/error_codes.html を参照。\n\n"
                          "- `4009`\n"
@@ -266,23 +266,21 @@ service ProjectService {
 
 message Project {
     // プロジェクトID
-    ProjectID id = 1;
+    ProjectID id = 1 [(google.api.field_behavior) = IDENTIFIER];
     // プロジェクト名
     string name = 2;
     // プロジェクトの説明
     string description = 3;
     // プロジェクトの位置情報
     trajectory.trjx_api_service.Position position = 4;
+    // 地図の初期表示半径 (単位: メートル)
+    // プロジェクトの中心座標から、この半径の範囲が収まるように地図のズームレベルを調整するために使用します。
+    optional float radius_meters = 5;
 }
 
 // プロジェクト作成リクエスト
 message CreateProjectRequest {
-    // プロジェクト名
-    string name = 1 [(google.api.field_behavior) = REQUIRED];
-    // プロジェクトの説明
-    string description = 2;
-    // プロジェクトの位置情報
-    trajectory.trjx_api_service.Position position = 3 [(google.api.field_behavior) = REQUIRED];
+    Project project = 1[(google.api.field_behavior) = REQUIRED];
 }
 
 // プロジェクト取得リクエスト
@@ -293,8 +291,8 @@ message GetProjectRequest {
 
 // プロジェクトリスト取得リクエスト
 message ListProjectsRequest {
-    optional int32 page_size = 1;  // ページサイズ, default= 25
-    optional string page_token = 2; // ページトークン
+    int32 page_size = 1;  // ページサイズ, default= 25
+    string page_token = 2; // ページトークン
 }
 
 // プロジェクトリスト取得レスポンス
@@ -310,8 +308,7 @@ message UpdateProjectRequest {
     // 更新するプロジェクトのフィールド。project.id は更新対象の特定に使用される（変更不可）
     Project project = 1 [(google.api.field_behavior) = REQUIRED];
     // 更新するフィールドのマスク
-    // 例: "name", "description", "position"
-    google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
+    google.protobuf.FieldMask update_mask = 2;
 }
 
 // プロジェクト削除リクエスト

--- a/trajectory_gcs_service/protocol/v1/project_service.proto
+++ b/trajectory_gcs_service/protocol/v1/project_service.proto
@@ -49,11 +49,11 @@ service ProjectService {
                         key: "application/json";
                         value: "{\n"
                                "  \"code\": 3,\n"
-                               "  \"message\": \"uavId is empty\",\n"
+                               "  \"message\": \"project name is empty\",\n"
                                "  \"details\": [\n"
                                "    {\n"
                                "      \"@type\": \"type.googleapis.com/trajectory.trajectory_gcs_service.protocol.v1.ErrorCode\",\n"
-                               "      \"errorCode\": 4001\n"
+                               "      \"errorCode\": 4009\n"
                                "    }\n"
                                "  ]\n"
                                "}";
@@ -64,204 +64,17 @@ service ProjectService {
     }
 
     // GetProject: プロジェクトの取得
-    rpc GetProject(GetProjectRequest) returns (Project) {
-        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "プロジェクトの取得する";
-            description: "プロジェクトの取得を行う。\n\n"
-                         "エラーレスポンスの`details`には、以下のエラーコードが含まれる可能性がある。\n"
-                         "エラーコードの詳細は https://trjxdoc.trajectory.jp/BEGatewaySpesification/error_codes.html を参照。\n\n"
-                         "- `4009`\n"
-                         "- `5039`";
-            parameters: {
-                headers: {
-                    name: "user_id"
-                    type: STRING
-                    description: "ユーザID"
-                    required: true
-                }
-                headers: {
-                    name: "Authorization"
-                    type: STRING
-                    description: "Bearer Token"
-                    required: true
-                }
-            }
-            responses: {
-                key: "400";
-                value: {
-                    description: "Invalid request.";
-                    schema: {
-                        json_schema: {
-                            ref: "#/definitions/rpcStatus";
-                        }
-                    };
-                    examples: {
-                        key: "application/json";
-                        value: "{\n"
-                               "  \"code\": 3,\n"
-                               "  \"message\": \"uavId is empty\",\n"
-                               "  \"details\": [\n"
-                               "    {\n"
-                               "      \"@type\": \"type.googleapis.com/trajectory.trajectory_gcs_service.protocol.v1.ErrorCode\",\n"
-                               "      \"errorCode\": 4001\n"
-                               "    }\n"
-                               "  ]\n"
-                               "}";
-                    }
-                }
-            }
-        };
-    }
+    rpc GetProject(GetProjectRequest) returns (Project);
 
     // ListProjects: プロジェクトのリスト取得
-    rpc ListProjects(ListProjectsRequest) returns (ListProjectsResponse) {
-        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "プロジェクトのリストを取得する";
-            description: "プロジェクトのリストを取得する。\n\n"
-                         "エラーレスポンスの`details`には、以下のエラーコードが含まれる可能性がある。\n"
-                         "エラーコードの詳細は https://trjxdoc.trajectory.jp/BEGatewaySpesification/error_codes.html を参照。\n\n"
-                         "- `4009`\n"
-                         "- `5039`";
-            parameters: {
-                headers: {
-                    name: "user_id"
-                    type: STRING
-                    description: "ユーザID"
-                    required: true
-                }
-                headers: {
-                    name: "Authorization"
-                    type: STRING
-                    description: "Bearer Token"
-                    required: true
-                }
-            }
-            responses: {
-                key: "400";
-                value: {
-                    description: "Invalid request.";
-                    schema: {
-                        json_schema: {
-                            ref: "#/definitions/rpcStatus";
-                        }
-                    };
-                    examples: {
-                        key: "application/json";
-                        value: "{\n"
-                               "  \"code\": 3,\n"
-                               "  \"message\": \"uavId is empty\",\n"
-                               "  \"details\": [\n"
-                               "    {\n"
-                               "      \"@type\": \"type.googleapis.com/trajectory.trajectory_gcs_service.protocol.v1.ErrorCode\",\n"
-                               "      \"errorCode\": 4001\n"
-                               "    }\n"
-                               "  ]\n"
-                               "}";
-                    }
-                }
-            }
-        };
-    }
+    rpc ListProjects(ListProjectsRequest) returns (ListProjectsResponse);
 
     // UpdateProject: プロジェクトの更新
-    rpc UpdateProject(UpdateProjectRequest) returns (Project) {
-        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "プロジェクトの更新する";
-            description: "プロジェクトの更新を行う。admin権限が必要。\n\n"
-                         "エラーレスポンスの`details`には、以下のエラーコードが含まれる可能性がある。\n"
-                         "エラーコードの詳細は https://trjxdoc.trajectory.jp/BEGatewaySpesification/error_codes.html を参照。\n\n"
-                         "- `4009`\n"
-                         "- `5039`";
-            parameters: {
-                headers: {
-                    name: "user_id"
-                    type: STRING
-                    description: "ユーザID"
-                    required: true
-                }
-                headers: {
-                    name: "Authorization"
-                    type: STRING
-                    description: "Bearer Token"
-                    required: true
-                }
-            }
-            responses: {
-                key: "400";
-                value: {
-                    description: "Invalid request.";
-                    schema: {
-                        json_schema: {
-                            ref: "#/definitions/rpcStatus";
-                        }
-                    };
-                    examples: {
-                        key: "application/json";
-                        value: "{\n"
-                               "  \"code\": 3,\n"
-                               "  \"message\": \"uavId is empty\",\n"
-                               "  \"details\": [\n"
-                               "    {\n"
-                               "      \"@type\": \"type.googleapis.com/trajectory.trajectory_gcs_service.protocol.v1.ErrorCode\",\n"
-                               "      \"errorCode\": 4001\n"
-                               "    }\n"
-                               "  ]\n"
-                               "}";
-                    }
-                }
-            }
-        };
-    }
+    rpc UpdateProject(UpdateProjectRequest) returns (Project);
 
     // DeleteProject: プロジェクトの削除
-    rpc DeleteProject(DeleteProjectRequest) returns (google.protobuf.Empty) {
-        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
-            summary: "プロジェクトの削除をする";
-            description: "プロジェクトの削除をする。admin権限が必要。\n\n"
-                         "エラーレスポンスの`details`には、以下のエラーコードが含まれる可能性がある。\n"
-                         "エラーコードの詳細は https://trjxdoc.trajectory.jp/BEGatewaySpesification/error_codes.html を参照。\n\n"
-                         "- `5039`\n"
-                         "- `5019`";
-            parameters: {
-                headers: {
-                    name: "user_id"
-                    type: STRING
-                    description: "ユーザID"
-                    required: true
-                }
-                headers: {
-                    name: "Authorization"
-                    type: STRING
-                    description: "Bearer Token"
-                    required: true
-                }
-            }
-            responses: {
-                key: "400";
-                value: {
-                    description: "Invalid request.";
-                    schema: {
-                        json_schema: {
-                            ref: "#/definitions/rpcStatus";
-                        }
-                    };
-                    examples: {
-                        key: "application/json";
-                        value: "{\n"
-                               "  \"code\": 3,\n"
-                               "  \"message\": \"uavId is empty\",\n"
-                               "  \"details\": [\n"
-                               "    {\n"
-                               "      \"@type\": \"type.googleapis.com/trajectory.trajectory_gcs_service.protocol.v1.ErrorCode\",\n"
-                               "      \"errorCode\": 4001\n"
-                               "    }\n"
-                               "  ]\n"
-                               "}";
-                    }
-                }
-            }
-        };
-    }
+    rpc DeleteProject(DeleteProjectRequest) returns (google.protobuf.Empty);
+    
 }
 
 message Project {

--- a/trajectory_gcs_service/protocol/v1/project_service.proto
+++ b/trajectory_gcs_service/protocol/v1/project_service.proto
@@ -1,0 +1,321 @@
+syntax = "proto3";
+
+package trajectory.trajectory_gcs_service.protocol.v1;
+
+option go_package = "github.com/trajectoryjp/trjx_api_service/trajectory_gcs";
+
+import "google/protobuf/empty.proto";
+import "google/api/field_behavior.proto";
+import "google/protobuf/field_mask.proto";
+import "protoc-gen-openapiv2/options/annotations.proto";
+import "github.com/trajectoryjp/trjx_api_service/type/resource.proto";
+import "github.com/trajectoryjp/trjx_api_service/trajectory_gcs_service/protocol/v1/resource.proto";
+
+// Project Service: プロジェクトの作成、リスト取得、更新、削除を行うサービス
+service ProjectService {
+    // CreateProject: プロジェクトの作成
+    rpc CreateProject(CreateProjectRequest) returns (Project) {
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            summary: "プロジェクトの作成する";
+            description: "プロジェクトの作成をする。\n\n"
+                         "エラーレスポンスの`details`には、以下のエラーコードが含まれる可能性がある。\n"
+                         "エラーコードの詳細は https://trjxdoc.trajectory.jp/BEGatewaySpesification/error_codes.html を参照。\n\n"
+                         "- `4009`\n"
+                         "- `5039`";
+            parameters: {
+                headers: {
+                    name: "user_id"
+                    type: STRING
+                    description: "ユーザID"
+                    required: true
+                }
+                headers: {
+                    name: "Authorization"
+                    type: STRING
+                    description: "Bearer Token"
+                    required: true
+                }
+            }
+            responses: {
+                key: "400";
+                value: {
+                    description: "Invalid request.";
+                    schema: {
+                        json_schema: {
+                            ref: "#/definitions/rpcStatus";
+                        }
+                    };
+                    examples: {
+                        key: "application/json";
+                        value: "{\n"
+                               "  \"code\": 3,\n"
+                               "  \"message\": \"uavId is empty\",\n"
+                               "  \"details\": [\n"
+                               "    {\n"
+                               "      \"@type\": \"type.googleapis.com/trajectory.trajectory_gcs_service.protocol.v1.ErrorCode\",\n"
+                               "      \"errorCode\": 4001\n"
+                               "    }\n"
+                               "  ]\n"
+                               "}";
+                    }
+                }
+            }
+        };
+    }
+
+    // GetProject: プロジェクトの取得
+    rpc GetProject(GetProjectRequest) returns (Project) {
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            summary: "プロジェクトの取得する";
+            description: "プロジェクトの取得を行う。\n\n"
+                         "エラーレスポンスの`details`には、以下のエラーコードが含まれる可能性がある。\n"
+                         "エラーコードの詳細は https://trjxdoc.trajectory.jp/BEGatewaySpesification/error_codes.html を参照。\n\n"
+                         "- `4009`\n"
+                         "- `5039`";
+            parameters: {
+                headers: {
+                    name: "user_id"
+                    type: STRING
+                    description: "ユーザID"
+                    required: true
+                }
+                headers: {
+                    name: "Authorization"
+                    type: STRING
+                    description: "Bearer Token"
+                    required: true
+                }
+            }
+            responses: {
+                key: "400";
+                value: {
+                    description: "Invalid request.";
+                    schema: {
+                        json_schema: {
+                            ref: "#/definitions/rpcStatus";
+                        }
+                    };
+                    examples: {
+                        key: "application/json";
+                        value: "{\n"
+                               "  \"code\": 3,\n"
+                               "  \"message\": \"uavId is empty\",\n"
+                               "  \"details\": [\n"
+                               "    {\n"
+                               "      \"@type\": \"type.googleapis.com/trajectory.trajectory_gcs_service.protocol.v1.ErrorCode\",\n"
+                               "      \"errorCode\": 4001\n"
+                               "    }\n"
+                               "  ]\n"
+                               "}";
+                    }
+                }
+            }
+        };
+    }
+
+    // ListProjects: プロジェクトのリスト取得
+    rpc ListProjects(ListProjectsRequest) returns (ListProjectsResponse) {
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            summary: "プロジェクトのリストを取得する";
+            description: "プロジェクトのリストを取得する。\n\n"
+                         "エラーレスポンスの`details`には、以下のエラーコードが含まれる可能性がある。\n"
+                         "エラーコードの詳細は https://trjxdoc.trajectory.jp/BEGatewaySpesification/error_codes.html を参照。\n\n"
+                         "- `4009`\n"
+                         "- `5039`";
+            parameters: {
+                headers: {
+                    name: "user_id"
+                    type: STRING
+                    description: "ユーザID"
+                    required: true
+                }
+                headers: {
+                    name: "Authorization"
+                    type: STRING
+                    description: "Bearer Token"
+                    required: true
+                }
+            }
+            responses: {
+                key: "400";
+                value: {
+                    description: "Invalid request.";
+                    schema: {
+                        json_schema: {
+                            ref: "#/definitions/rpcStatus";
+                        }
+                    };
+                    examples: {
+                        key: "application/json";
+                        value: "{\n"
+                               "  \"code\": 3,\n"
+                               "  \"message\": \"uavId is empty\",\n"
+                               "  \"details\": [\n"
+                               "    {\n"
+                               "      \"@type\": \"type.googleapis.com/trajectory.trajectory_gcs_service.protocol.v1.ErrorCode\",\n"
+                               "      \"errorCode\": 4001\n"
+                               "    }\n"
+                               "  ]\n"
+                               "}";
+                    }
+                }
+            }
+        };
+    }
+
+    // UpdateProject: プロジェクトの更新
+    rpc UpdateProject(UpdateProjectRequest) returns (Project) {
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            summary: "プロジェクトの更新する";
+            description: "プロジェクトの更新を行う。admin権限が必要。\n\n"
+                         "エラーレスポンスの`details`には、以下のエラーコードが含まれる可能性がある。\n"
+                         "エラーコードの詳細は https://trjxdoc.trajectory.jp/BEGatewaySpesification/error_codes.html を参照。\n\n"
+                         "- `4009`\n"
+                         "- `5039`";
+            parameters: {
+                headers: {
+                    name: "user_id"
+                    type: STRING
+                    description: "ユーザID"
+                    required: true
+                }
+                headers: {
+                    name: "Authorization"
+                    type: STRING
+                    description: "Bearer Token"
+                    required: true
+                }
+            }
+            responses: {
+                key: "400";
+                value: {
+                    description: "Invalid request.";
+                    schema: {
+                        json_schema: {
+                            ref: "#/definitions/rpcStatus";
+                        }
+                    };
+                    examples: {
+                        key: "application/json";
+                        value: "{\n"
+                               "  \"code\": 3,\n"
+                               "  \"message\": \"uavId is empty\",\n"
+                               "  \"details\": [\n"
+                               "    {\n"
+                               "      \"@type\": \"type.googleapis.com/trajectory.trajectory_gcs_service.protocol.v1.ErrorCode\",\n"
+                               "      \"errorCode\": 4001\n"
+                               "    }\n"
+                               "  ]\n"
+                               "}";
+                    }
+                }
+            }
+        };
+    }
+
+    // DeleteProject: プロジェクトの削除
+    rpc DeleteProject(DeleteProjectRequest) returns (google.protobuf.Empty) {
+        option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+            summary: "プロジェクトの削除をする";
+            description: "プロジェクトの削除をする。admin権限が必要。\n\n"
+                         "エラーレスポンスの`details`には、以下のエラーコードが含まれる可能性がある。\n"
+                         "エラーコードの詳細は https://trjxdoc.trajectory.jp/BEGatewaySpesification/error_codes.html を参照。\n\n"
+                         "- `5039`\n"
+                         "- `5019`";
+            parameters: {
+                headers: {
+                    name: "user_id"
+                    type: STRING
+                    description: "ユーザID"
+                    required: true
+                }
+                headers: {
+                    name: "Authorization"
+                    type: STRING
+                    description: "Bearer Token"
+                    required: true
+                }
+            }
+            responses: {
+                key: "400";
+                value: {
+                    description: "Invalid request.";
+                    schema: {
+                        json_schema: {
+                            ref: "#/definitions/rpcStatus";
+                        }
+                    };
+                    examples: {
+                        key: "application/json";
+                        value: "{\n"
+                               "  \"code\": 3,\n"
+                               "  \"message\": \"uavId is empty\",\n"
+                               "  \"details\": [\n"
+                               "    {\n"
+                               "      \"@type\": \"type.googleapis.com/trajectory.trajectory_gcs_service.protocol.v1.ErrorCode\",\n"
+                               "      \"errorCode\": 4001\n"
+                               "    }\n"
+                               "  ]\n"
+                               "}";
+                    }
+                }
+            }
+        };
+    }
+}
+
+message Project {
+    // プロジェクトID
+    ProjectID id = 1;
+    // プロジェクト名
+    string name = 2;
+    // プロジェクトの説明
+    string description = 3;
+    // プロジェクトの位置情報
+    trajectory.trjx_api_service.Position position = 4;
+}
+
+// プロジェクト作成リクエスト
+message CreateProjectRequest {
+    // プロジェクト名
+    string name = 1 [(google.api.field_behavior) = REQUIRED];
+    // プロジェクトの説明
+    string description = 2;
+    // プロジェクトの位置情報
+    trajectory.trjx_api_service.Position position = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+// プロジェクト取得リクエスト
+message GetProjectRequest {
+    // 取得するプロジェクトID
+    ProjectID id = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
+// プロジェクトリスト取得リクエスト
+message ListProjectsRequest {
+    optional int32 page_size = 1;  // ページサイズ, default= 25
+    optional string page_token = 2; // ページトークン
+}
+
+// プロジェクトリスト取得レスポンス
+message ListProjectsResponse {
+    // プロジェクトのリスト
+    repeated Project projects = 1;
+    // 次のページトークン
+    string next_page_token = 2;
+}
+
+// プロジェクト更新リクエスト
+message UpdateProjectRequest {
+    // 更新するプロジェクトのフィールド。project.id は更新対象の特定に使用される（変更不可）
+    Project project = 1 [(google.api.field_behavior) = REQUIRED];
+    // 更新するフィールドのマスク
+    // 例: "name", "description", "position"
+    google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+// プロジェクト削除リクエスト
+message DeleteProjectRequest {
+    // 削除するプロジェクトID
+    ProjectID id = 1 [(google.api.field_behavior) = REQUIRED];
+}


### PR DESCRIPTION
This pull request introduces a new gRPC service definition for managing projects in the `trajectory_gcs_service` API. It defines the `ProjectService` with all necessary RPC methods for creating, retrieving, listing, updating, and deleting projects, along with their request and response message types. The service is well-documented with OpenAPI annotations for improved API gateway integration and error handling.

**New Project Management API:**

* Added the `ProjectService` gRPC service with the following RPC methods: `CreateProject`, `GetProject`, `ListProjects`, `UpdateProject`, and `DeleteProject`, each with detailed OpenAPI annotations for documentation, request/response structure, and error handling.
* Defined the `Project` message and associated request/response messages (`CreateProjectRequest`, `GetProjectRequest`, `ListProjectsRequest`, `ListProjectsResponse`, `UpdateProjectRequest`, `DeleteProjectRequest`) to support all CRUD operations for projects, including support for pagination and field masks for updates.
* Incorporated required field behaviors and example error responses to ensure robust API usage and clear error reporting.